### PR TITLE
give hint to operator as to what is creating temp files

### DIFF
--- a/repository_fetcher/verify.go
+++ b/repository_fetcher/verify.go
@@ -27,7 +27,7 @@ func Verify(r io.Reader, d digest.Digest) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	tmp, err := ioutil.TempFile("", "")
+	tmp, err := ioutil.TempFile("", "verifier")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This was hard to debug as we were just seeing file names such as `703473976` fill up our disk.