### PR TITLE
Do not set writeback option for ext4

### DIFF
--- a/docker_drivers/aufs/loop.go
+++ b/docker_drivers/aufs/loop.go
@@ -15,7 +15,7 @@ type Loop struct {
 func (lm *Loop) MountFile(filePath, destPath string) error {
 	log := lm.Logger.Session("mount-file", lager.Data{"filePath": filePath, "destPath": destPath})
 
-	output, err := exec.Command("mount", "-n", "-t", "ext4", "-o", "loop,noatime,data=writeback",
+	output, err := exec.Command("mount", "-n", "-t", "ext4", "-o", "loop,noatime",
 		filePath, destPath).CombinedOutput()
 	if err != nil {
 		log.Error("mounting", err, lager.Data{"output": string(output)})

--- a/docker_drivers/aufs/loop_linux_test.go
+++ b/docker_drivers/aufs/loop_linux_test.go
@@ -65,7 +65,7 @@ var _ = Describe("LoopLinux", func() {
 	})
 
 	Describe("MountFile", func() {
-		It("mounts the file with noatime and journal_data_writeback options", func() {
+		It("mounts the file with noatime but not the journal_data_writeback options", func() {
 			Expect(loop.MountFile(bsFilePath, destPath)).To(Succeed())
 
 			session, err := gexec.Start(exec.Command("losetup", "-j", bsFilePath), GinkgoWriter, GinkgoWriter)
@@ -74,7 +74,8 @@ var _ = Describe("LoopLinux", func() {
 
 			session, err = gexec.Start(exec.Command("cat", "/proc/mounts"), GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
-			Eventually(session).Should(gbytes.Say(fmt.Sprintf("%s %s ext4 rw,noatime,data=writeback", loopDev, destPath)))
+			Eventually(session).Should(gbytes.Say(fmt.Sprintf("%s %s ext4 rw,noatime", loopDev, destPath)))
+			Expect(session).NotTo(gbytes.Say(",data=writeback"))
 		})
 
 		Context("when using a file that does not exist", func() {


### PR DESCRIPTION
The following tests passed when targeting Concourse workers with stemcell 3232.11 / kernel 3.19:
- `./scripts/remote-fly ci/nested-shed-tests.yml` 
- `./scripts/remote-fly ci/gits.yml`

I'm struggling to deploy a second set of Concourse workers with a kernel 4.4 stemcell, so I can't guarantee this actually gets Garden working on kernel 4.4.  But at least it's progress.

- [Garden story](https://www.pivotaltracker.com/story/show/120000259)
- [Container Networking story](https://www.pivotaltracker.com/story/show/122007251)

cc: @julz 